### PR TITLE
Update to ONVM v19.05 APIs

### DIFF
--- a/mtcp/src/core.c
+++ b/mtcp/src/core.c
@@ -99,7 +99,7 @@ HandleSignal(int signal)
 
 #ifdef ENABLE_ONVM
 		if (current_iomodule_func == &onvm_module_func)
-			onvm_nflib_stop(CONFIG.nf_info);
+			onvm_nflib_stop(CONFIG.nf_local_ctx);
 #endif
 		core = sched_getcpu();
 		clock_gettime(CLOCK_REALTIME, &cur_ts);
@@ -1640,7 +1640,7 @@ mtcp_destroy()
 #endif
 
 #ifdef ENABLE_ONVM
-	onvm_nflib_stop(CONFIG.nf_info);
+	onvm_nflib_stop(CONFIG.nf_local_ctx);
 #endif
 
 	TRACE_INFO("All MTCP threads are joined.\n");

--- a/mtcp/src/include/mtcp.h
+++ b/mtcp/src/include/mtcp.h
@@ -183,7 +183,7 @@ struct mtcp_config
 	uint8_t multi_process_is_master;
 
 #ifdef ENABLE_ONVM
-	struct onvm_nf_info *nf_info;
+	struct onvm_nf_local_ctx *nf_local_ctx;
 	/* onvm specific args */
 	uint16_t onvm_serv;
   	uint16_t onvm_inst;

--- a/mtcp/src/io_module.c
+++ b/mtcp/src/io_module.c
@@ -596,8 +596,9 @@ SetNetEnv(char *dev_name_list, char *port_stat_list)
 		 */
 		optind = 0;
 
-		/* initialize the dpdk eal env */
-		ret = onvm_nflib_init(argc, argv, "mtcp_nf", &CONFIG.nf_info);
+		/* Initialize onvm */
+                CONFIG.nf_local_ctx = onvm_nflib_init_nf_local_ctx();
+		ret = onvm_nflib_init(argc, argv, "mtcp_nf", CONFIG.nf_local_ctx, NULL);
 		if (ret < 0) {
 			TRACE_ERROR("Invalid EAL args!\n");
 			exit(EXIT_FAILURE);

--- a/mtcp/src/onvm_module.c
+++ b/mtcp/src/onvm_module.c
@@ -134,10 +134,10 @@ onvm_init_handle(struct mtcp_thread_context *ctxt)
 	dpc->pktmbuf_pool = pktmbuf_pool;
 
 	/* Complete onvm handshake */
-	onvm_nflib_nf_ready(CONFIG.nf_info);
+	onvm_nflib_nf_ready(CONFIG.nf_local_ctx->nf);
 	
 	/* Initialize onvm rings*/
-	nf = onvm_nflib_get_nf(CONFIG.nf_info->instance_id);
+	nf = CONFIG.nf_local_ctx->nf;
 	rx_ring = nf->rx_q;
 	tx_ring = nf->tx_q;
 


### PR DESCRIPTION
We're currently in the middle of releasing ONVM v19.05, which includes API modifications this PR updates the API calls to properly work with the latest ONVM version.

@dennisafa I didn't test can you verify that everything works as expected? 